### PR TITLE
Initial support for library hyperlinks to java files (#65)

### DIFF
--- a/plugin/META-INF/MANIFEST.MF
+++ b/plugin/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 1.4.0
 Bundle-Activator: com.nitorcreations.robotframework.eclipseide.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
+ org.eclipse.jdt.core,
  org.eclipse.jface.text,
  org.eclipse.ui.editors,
  org.eclipse.core.resources,

--- a/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/IResourceManager.java
+++ b/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/IResourceManager.java
@@ -27,6 +27,8 @@ public interface IResourceManager {
 
     IFile getRelativeFile(IFile originalFile, String pathRelativeToOriginalFile);
 
+    IFile getJavaFile(String fullyQualifiedName);
+
     IDocument resolveDocumentFor(IFile file);
 
     IFile resolveFileFor(IDocument document);

--- a/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/ResourceManager.java
+++ b/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/ResourceManager.java
@@ -23,8 +23,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
@@ -125,6 +131,26 @@ public final class ResourceManager implements IResourceManager {
 
     private URI uriForPath(IPath path) {
         return new File(path.toString()).toURI();
+    }
+
+    @Override
+    public IFile getJavaFile(String fullyQualifiedName) {
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        for (IProject project : root.getProjects()) {
+            try {
+                IJavaProject javaProject = JavaCore.create(project);
+                IType type = javaProject.findType(fullyQualifiedName);
+                if (type != null) {
+                    IFile file = root.getFile(type.getPath());
+                    if (file.exists()) {
+                        return file;
+                    }
+                }
+            } catch (JavaModelException e) {
+                // non-Java or unopened projects are simple skipped
+            }
+        }
+        return null;
     }
 
     @Override

--- a/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/RobotSourceViewerConfiguration.java
+++ b/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/editors/RobotSourceViewerConfiguration.java
@@ -40,6 +40,7 @@ import com.nitorcreations.robotframework.eclipseide.internal.assistant.proposalg
 import com.nitorcreations.robotframework.eclipseide.internal.assistant.proposalgenerator.ProposalSuitabilityDeterminer;
 import com.nitorcreations.robotframework.eclipseide.internal.assistant.proposalgenerator.RelevantProposalsFilter;
 import com.nitorcreations.robotframework.eclipseide.internal.hyperlinks.KeywordCallHyperlinkDetector;
+import com.nitorcreations.robotframework.eclipseide.internal.hyperlinks.LibraryHyperlinkDetector;
 import com.nitorcreations.robotframework.eclipseide.internal.hyperlinks.ResourceHyperlinkDetector;
 import com.nitorcreations.robotframework.eclipseide.internal.hyperlinks.VariableAccessHyperlinkDetector;
 
@@ -75,6 +76,7 @@ public class RobotSourceViewerConfiguration extends TextSourceViewerConfiguratio
         detectors.add(new ResourceHyperlinkDetector());
         detectors.add(new KeywordCallHyperlinkDetector());
         detectors.add(new VariableAccessHyperlinkDetector());
+        detectors.add(new LibraryHyperlinkDetector());
         return detectors.toArray(new IHyperlinkDetector[detectors.size()]);
     }
 

--- a/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/internal/hyperlinks/LibraryHyperlinkDetector.java
+++ b/plugin/src/main/java/com/nitorcreations/robotframework/eclipseide/internal/hyperlinks/LibraryHyperlinkDetector.java
@@ -1,0 +1,45 @@
+package com.nitorcreations.robotframework.eclipseide.internal.hyperlinks;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import com.nitorcreations.robotframework.eclipseide.PluginContext;
+import com.nitorcreations.robotframework.eclipseide.builder.parser.RobotLine;
+import com.nitorcreations.robotframework.eclipseide.internal.util.FileType;
+import com.nitorcreations.robotframework.eclipseide.internal.util.FileWithType;
+import com.nitorcreations.robotframework.eclipseide.structure.ParsedString;
+import com.nitorcreations.robotframework.eclipseide.structure.ParsedString.ArgumentType;
+
+/**
+ * This hyperlink detector creates hyperlinks for library references in any projects of the workspace, e.g.
+ * <ul>
+ * <li><tt>Library com.company.TestLib</tt> - "TestLib.java" is linked</li>
+ * </ul>
+ */
+public class LibraryHyperlinkDetector extends HyperlinkDetector {
+
+    @Override
+    protected void getLinks(IFile file, RobotLine rfeLine, ParsedString argument, int offset, List<IHyperlink> links) {
+        if (isLibraryLineWithFileArgument(rfeLine, argument)) {
+            String fullyQualifiedName = argument.getUnescapedValue();
+            IFile targetJavaFile = PluginContext.getResourceManager().getJavaFile(fullyQualifiedName);
+            if (targetJavaFile != null) {
+                links.add(createLinkForArgument(argument, targetJavaFile, fullyQualifiedName));
+            }
+        }
+    }
+
+    private boolean isLibraryLineWithFileArgument(RobotLine rfeLine, ParsedString argument) {
+        return rfeLine.isLibrarySetting() && argument.getType() == ArgumentType.SETTING_FILE;
+    }
+
+    private Hyperlink createLinkForArgument(ParsedString argument, IFile targetFile, String linkText) {
+        IRegion linkRegion = new Region(argument.getArgCharPos(), argument.getValue().length());
+        FileWithType targetFileWithType = new FileWithType(FileType.LIBRARY, targetFile);
+        return new Hyperlink(linkRegion, linkText, null, targetFileWithType);
+    }
+}


### PR DESCRIPTION
- new HyperlinkDetector class for Libraries which creates java links
- IResourceManager is extended with java file lookup method (getJavaFile())
- implementation of the java file lookup method
  -- using org.eclipse.jdt.core plugin
